### PR TITLE
Add pre-commit hooks in the rust template.

### DIFF
--- a/rust-lib-template/.githooks/README.txt
+++ b/rust-lib-template/.githooks/README.txt
@@ -1,0 +1,3 @@
+To globally enable githooks, run:
+
+git config core.hooksPath .githooks

--- a/rust-lib-template/.githooks/pre-commit
+++ b/rust-lib-template/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Runs automatic formatting and tests
+
+exec cargo fmt -- --check
+exec cargo build --all-features
+exec cargo test --all-features

--- a/rust-lib-template/README.md
+++ b/rust-lib-template/README.md
@@ -15,6 +15,7 @@ This is a template project for a general Rust based Biodivine library. It comes 
 Provided features:
  - Travis integration pre-configured with Codecov code coverage.
  - `LICENSE` and `.gitignore` files.
+ - Git hooks to verify formatting and tests integrity before committing (run `git config core.hooksPath .githooks` to enable local git hooks).
  - Run `cargo make rich-doc` and `cargo make rich-doc-dev` to generate documentation with Mermaid and KaTeX enabled (`dev` variant includes also internal functions).
  - Run `cargo make` to run standard test process and compile basic docs, but also run automatic formatting tool of source code (make sure you apply formatting every time before commit).
  - There is a `shields_up` feature flag that can be used to include extra safety checks (invariants, pre-/post-conditions) that should not be needed but may be useful for testing. For usage examples, see the Biodivine Rust developer guide. The flag is off by default, but is enabled during tests on Travis. We provide variants of basic commands with the 


### PR DESCRIPTION
It can be argued that it is useful to never commit invalid code. Or sometimes you just forget to run tests and when it hits CI its too late... This PR adds git pre-commit hook to the rust lib template that will run cargo formatting and test checks before every commit, ensuring we never unintentionally commit broken code.

> Hooks need to be enabled on every machine using `git config core.hooksPath .githooks`