### PR TITLE
Additional checks for Travis

### DIFF
--- a/rust-lib-template/.travis.yml
+++ b/rust-lib-template/.travis.yml
@@ -14,13 +14,20 @@ matrix:
   allow_failures:
     - rust: nightly
 
+env: RUSTFLAGS="-D warnings"
+
 before_cache: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
     cargo install cargo-tarpaulin
   fi
 
+before_script:
+  - rustup component add clippy
+
 script:
   - cargo clean
+  - cargo fmt -- --check
+  - cargo clippy
   - cargo build
   - cargo test --features "shields_up"
 


### PR DESCRIPTION
In this PR, we add extra verification steps to the Travis CI script. Specifically: 

1. Treat warnings as errors. While sometimes acceptable, warnings should be generally avoided.
2. Check cargo formatting. Ensure project follows standard code style enforced by cargo.
3. Use clippy (rust lint tool) to verify other coding practices, line unnecessary `if` or `return` statements or simple performance anti-patterns.